### PR TITLE
Handle enum options with empty labels

### DIFF
--- a/dist/lib/settings-manager.js
+++ b/dist/lib/settings-manager.js
@@ -425,9 +425,7 @@ class SettingsManager {
           throw new Error(`${setting.description} is missing enum options`);
         }
 
-        if (
-          !Object.prototype.hasOwnProperty.call(setting.options, value)
-        ) {
+        if (!Object.prototype.hasOwnProperty.call(setting.options, value)) {
           const validOptions = Object.keys(setting.options).join(", ");
           throw new Error(
             `${setting.description} must be one of: ${validOptions}`,

--- a/dist/lib/settings-manager.js
+++ b/dist/lib/settings-manager.js
@@ -425,7 +425,9 @@ class SettingsManager {
           throw new Error(`${setting.description} is missing enum options`);
         }
 
-        if (!setting.options[value]) {
+        if (
+          !Object.prototype.hasOwnProperty.call(setting.options, value)
+        ) {
           const validOptions = Object.keys(setting.options).join(", ");
           throw new Error(
             `${setting.description} must be one of: ${validOptions}`,

--- a/dist/lib/validation.js
+++ b/dist/lib/validation.js
@@ -265,6 +265,21 @@ function validateSettingDetailed(setting) {
         }
         break;
 
+      case "enum":
+        if (!setting.options || typeof setting.options !== "object") {
+          isValid = false;
+          errorMessage = "Enum setting is missing options";
+        } else if (
+          !Object.prototype.hasOwnProperty.call(setting.options, setting.value)
+        ) {
+          isValid = false;
+          const validOptions = Object.keys(setting.options).join(", ");
+          errorMessage = `Value must be one of: ${validOptions}`;
+        } else {
+          isValid = true;
+        }
+        break;
+
       default:
         isValid = false;
         errorMessage = `Unknown setting type: ${setting.type}`;

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,9 @@ module.exports = {
   testMatch: [
     "<rootDir>/test/validation.test.js",
     "<rootDir>/test/config-loader.test.js",
+    "<rootDir>/test/settings-manager.test.js",
     // Other pure function tests would go here
-    // settings-manager.test.js and storage.test.js moved to E2E (browser integration)
+    // storage.test.js moved to E2E (browser integration)
   ],
 
   // Module paths

--- a/lib/settings-manager.js
+++ b/lib/settings-manager.js
@@ -425,9 +425,7 @@ class SettingsManager {
           throw new Error(`${setting.description} is missing enum options`);
         }
 
-        if (
-          !Object.prototype.hasOwnProperty.call(setting.options, value)
-        ) {
+        if (!Object.prototype.hasOwnProperty.call(setting.options, value)) {
           const validOptions = Object.keys(setting.options).join(", ");
           throw new Error(
             `${setting.description} must be one of: ${validOptions}`,

--- a/lib/settings-manager.js
+++ b/lib/settings-manager.js
@@ -425,7 +425,9 @@ class SettingsManager {
           throw new Error(`${setting.description} is missing enum options`);
         }
 
-        if (!setting.options[value]) {
+        if (
+          !Object.prototype.hasOwnProperty.call(setting.options, value)
+        ) {
           const validOptions = Object.keys(setting.options).join(", ");
           throw new Error(
             `${setting.description} must be one of: ${validOptions}`,

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -265,6 +265,21 @@ function validateSettingDetailed(setting) {
         }
         break;
 
+      case "enum":
+        if (!setting.options || typeof setting.options !== "object") {
+          isValid = false;
+          errorMessage = "Enum setting is missing options";
+        } else if (
+          !Object.prototype.hasOwnProperty.call(setting.options, setting.value)
+        ) {
+          isValid = false;
+          const validOptions = Object.keys(setting.options).join(", ");
+          errorMessage = `Value must be one of: ${validOptions}`;
+        } else {
+          isValid = true;
+        }
+        break;
+
       default:
         isValid = false;
         errorMessage = `Unknown setting type: ${setting.type}`;

--- a/test/settings-manager.test.js
+++ b/test/settings-manager.test.js
@@ -1,0 +1,16 @@
+const SettingsManager = require("../lib/settings-manager");
+
+// Minimal tests for SettingsManager validateSetting enum handling
+
+describe("SettingsManager", () => {
+  test("validateSetting should accept enum options with empty labels", () => {
+    const manager = new SettingsManager();
+    const setting = {
+      type: "enum",
+      description: "Enum with empty label",
+      options: { option1: "", option2: "Label" },
+    };
+
+    expect(() => manager.validateSetting(setting, "option1")).not.toThrow();
+  });
+});

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -202,6 +202,18 @@ describe("Settings Validation", () => {
     });
   });
 
+  describe("Enum Validation", () => {
+    test("should validate valid enum values", () => {
+      const options = { option1: "", option2: "Second" };
+      expect(validateSetting("enum", "option1", { options })).toBe(true);
+    });
+
+    test("should reject invalid enum values", () => {
+      const options = { option1: "First", option2: "Second" };
+      expect(validateSetting("enum", "missing", { options })).toBe(false);
+    });
+  });
+
   describe("Setting Schema Validation", () => {
     test("should validate complete setting object", () => {
       const validSetting = {


### PR DESCRIPTION
## Summary
- add explicit enum validation to validation utilities
- ensure SettingsManager checks enum options by key, allowing empty labels
- test enum handling and expand Jest config to include SettingsManager tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a00d2ab4748320a5ce698f7fce0d69